### PR TITLE
Include warnings for plain function types in DEBUG

### DIFF
--- a/src/core/ReactLegacyElement.js
+++ b/src/core/ReactLegacyElement.js
@@ -136,7 +136,7 @@ ReactLegacyElementFactory.wrapCreateFactory = function(createFactory) {
       return createFactory(type.type);
     }
 
-    if (__DEV__) {
+    if (__DEBUG__) {
       warnForPlainFunctionType(type);
     }
 
@@ -182,7 +182,7 @@ ReactLegacyElementFactory.wrapCreateElement = function(createElement) {
       return createElement.apply(this, args);
     }
 
-    if (__DEV__) {
+    if (__DEBUG__) {
       warnForPlainFunctionType(type);
     }
 


### PR DESCRIPTION
_Before_ submitting a pull request, please make sure the following is done...
1. Fork the repo and create your branch from `master`.
2. If you've added code that should be tested, add tests!
3. If you've changed APIs, update the documentation.
4. Ensure the test suite passes (`grunt test`).
5. Make sure your code lints (`grunt lint`) - we've done our best to make sure these rules match our internal linting guidelines.
6. If you haven't already, complete the [CLA](https://code.facebook.com/cla).

This includes warnings about cases where we pass a factory (or, probably more uncommon) a type to `createElement` or `createFactory`.

I.e. to warn about the future-not-supported scenario:

```
# my_component.js
MyComponent = React.createClass({ ... });
exports.MyComponent = React.createFactory(MyComponent);

# some_other_component.js
MyComponent = require('my_component.js').MyComponent;

SomeOtherComponent = React.createClass({
  render: function() {
    React.createElement(MyComponent);  
  }
});
```
